### PR TITLE
See if I can get it to install without the .2 R version spec

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(
   )
 Description: Import foreign statistical formats into R via the ReadStat C
     library.
-Depends: R (>= 3.1.2)
+Depends: R (>= 3.1.0)
 Suggests: dplyr,
     testthat
 License: MIT + file LICENSE


### PR DESCRIPTION
Is there a specific reason to restrict this package to the 3.1.2 R point release? Specifically, can it go to >= 3.1.0? 

It doesn't seem to be related to Imports or Suggests dependencies. 