### PR TITLE
Modify DfBuilder to include "Numeric" label types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 
 * hms objects deal better with missings when printing.
 
+* Fixed bug causing labels for numeric variables to be read in as
+  integers and associated error:
+  ``Error: `x` and `labels` must be same type``
+
 # haven 0.1.1
 
 * Fixed memory initialisation problems found by valgrind.

--- a/src/DfBuilder.cpp
+++ b/src/DfBuilder.cpp
@@ -6,34 +6,56 @@ using namespace Rcpp;
 class LabelSet {
   std::vector<std::string> labels_;
   std::vector<std::string> values_s_;
+  std::vector<int> values_i_;
   std::vector<double> values_d_;
 
 public:
   LabelSet() {}
 
   void add(char* value, std::string label) {
-    if (values_d_.size() > 0)
-      stop("Can't add string to integer labelset");
+    if (values_i_.size() > 0 || values_d_.size() > 0)
+      stop("Can't add string to integer/double labelset");
 
     std::string string(value);
     values_s_.push_back(string);
     labels_.push_back(label);
   }
 
+  void add(int value, std::string label) {
+    if (values_d_.size() > 0 || values_s_.size() > 0)
+      stop("Can't add integer to string/double labelset");
+
+    values_i_.push_back(value);
+    labels_.push_back(label);
+  }
+
   void add(double value, std::string label) {
-    if (values_s_.size() > 0)
-      stop("Can't add integer to string labelset");
+    if (values_i_.size() > 0 || values_s_.size() > 0)
+      stop("Can't add double to integer/string labelset");
 
     values_d_.push_back(value);
     labels_.push_back(label);
   }
 
+
   RObject labels() const {
     RObject out;
 
-    if (values_d_.size() > 0) {
-      int n = values_d_.size();
+    if (values_i_.size() > 0) {
+      int n = values_i_.size();
       IntegerVector values(n);
+      CharacterVector labels(n);
+
+      for (int i = 0; i < n; ++i) {
+        values[i] = values_i_[i];
+        labels[i] = Rf_mkCharCE(labels_[i].c_str(), CE_UTF8);
+      }
+
+      values.attr("names") = labels;
+      out = values;
+    } else if (values_d_.size() > 0) {
+      int n = values_d_.size();
+      NumericVector values(n);
       CharacterVector labels(n);
 
       for (int i = 0; i < n; ++i) {

--- a/tests/testthat/test-read-sas.R
+++ b/tests/testthat/test-read-sas.R
@@ -17,8 +17,8 @@ test_that("value labels parsed from bcat file", {
 test_that("value labels read in as same type as vector", {
   df <- read_sas("hadley.sas7bdat", "formats.sas7bcat")
 
-  expect_equal(class(as.vector(df$gender)), class(attr(df$gender, "labels")))
-  expect_equal(class(as.vector(df$workshop)), class(attr(df$workshop, "labels")))
+  expect_equal(typeof(df$gender), typeof(attr(df$gender, "labels")))
+  expect_equal(typeof(df$workshop), typeof(attr(df$workshop, "labels")))
 })
 
 test_that("date times are converted into corresponding R types", {

--- a/tests/testthat/test-read-sas.R
+++ b/tests/testthat/test-read-sas.R
@@ -14,6 +14,13 @@ test_that("value labels parsed from bcat file", {
   expect_equal(attr(df$workshop, "labels"), c(R = 1, SAS = 2))
 })
 
+test_that("value labels read in as same type as vector", {
+  df <- read_sas("hadley.sas7bdat", "formats.sas7bcat")
+
+  expect_equal(class(as.vector(df$gender)), class(attr(df$gender, "labels")))
+  expect_equal(class(as.vector(df$workshop)), class(attr(df$workshop, "labels")))
+})
+
 test_that("date times are converted into corresponding R types", {
   df <- read_sas("datetime.sas7bdat")
   expect_equal(df$VAR1[1], ISOdatetime(2015, 02, 02, 14, 42, 12, "UTC"))

--- a/tests/testthat/test-read-sav.R
+++ b/tests/testthat/test-read-sav.R
@@ -18,9 +18,9 @@ test_that("value labels read in as same type as vector", {
   num <- read_sav("labelled-num.sav")
   str <- read_sav("labelled-str.sav")
 
-  expect_equal(class(as.vector(df$sex)), class(attr(df$sex, "labels")))
-  expect_equal(class(as.vector(num[[1]])), class(attr(num[[1]], "labels")))
-  expect_equal(class(as.vector(str[[1]])), class(attr(str[[1]], "labels")))
+  expect_equal(typeof(df$sex), typeof(attr(df$sex, "labels")))
+  expect_equal(typeof(num[[1]]), typeof(attr(num[[1]], "labels")))
+  expect_equal(typeof(str[[1]]), typeof(attr(str[[1]], "labels")))
 })
 
 test_that("missing values encoded as NA", {

--- a/tests/testthat/test-read-sav.R
+++ b/tests/testthat/test-read-sav.R
@@ -13,6 +13,16 @@ test_that("value labels stored as labelled class", {
   expect_equal(str[[1]], labelled(c("M", "F"), c(Female = "F", Male = "M")))
 })
 
+test_that("value labels read in as same type as vector", {
+  df <- read_sav("variable-label.sav")
+  num <- read_sav("labelled-num.sav")
+  str <- read_sav("labelled-str.sav")
+
+  expect_equal(class(as.vector(df$sex)), class(attr(df$sex, "labels")))
+  expect_equal(class(as.vector(num[[1]])), class(attr(num[[1]], "labels")))
+  expect_equal(class(as.vector(str[[1]])), class(attr(str[[1]], "labels")))
+})
+
 test_that("missing values encoded as NA", {
   num <- read_sav("labelled-num-na.sav")[[1]]
 
@@ -25,3 +35,4 @@ test_that("non-ASCII labels converted to utf-8", {
   expect_equal(attr(x, "label"), "This is an \u00e4-umlaut")
   expect_equal(names(attr(x, "labels"))[1], "the \u00e4 umlaut")
 })
+


### PR DESCRIPTION
To resolve issue #26 - added support for "Numeric" label types.