### PR TITLE
Fixed a (small) bug in as_factor.labelled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # haven 0.2.0.9000
 
 # haven 0.2.0
+* fixed a bug in `as_factor.labelled`, which generated <NA>'s and wrong 
+  labels for integer labels
 
 * `zap_labels()` now leaves unlabelled vectors unchanged, making it easier
   to apply to all columns.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 # haven 0.2.0
 * fixed a bug in `as_factor.labelled`, which generated <NA>'s and wrong 
-  labels for integer labels
+  labels for integer labels.
 
 * `zap_labels()` now leaves unlabelled vectors unchanged, making it easier
   to apply to all columns.

--- a/R/labelled.R
+++ b/R/labelled.R
@@ -96,7 +96,7 @@ as_factor.labelled <- function(x, levels = c("labels", "values"),
     factor(x, levs, labels = labs, ordered = ordered)
   } else {
     labs <- attr(x, "labels")
-    factor(match(x, labs), levels = unname(labs), labels = names(labs))
+    factor(x, levels = unname(labs), labels = names(labs))
   }
 
 }

--- a/tests/testthat/test-labelled.R
+++ b/tests/testthat/test-labelled.R
@@ -16,3 +16,13 @@ test_that("can coerce single value labelled vectors into factor", {
   var <- labelled(1L, c(female = 1L, male = 2L))
   expect_equal(as_factor(var), factor("female", levels = c("female", "male")))
 })
+
+test_that("integer labels that are not equal to vector positions work", {
+  var <- labelled(1L, c(female = 2L, male = 1L))
+  expect_equal(as_factor(var), factor("male", levels = c("female", "male")))
+})
+
+test_that("integer labels that are larger then label list work", {
+  var <- labelled(11L, c(female = 11L, male = 12L))
+  expect_equal(as_factor(var), factor("female", levels = c("female", "male")))
+})


### PR DESCRIPTION
Hi Hadley,

I came across a small bug in `as_factor.labelled`:

```
var <- labelled(1L, c(female = 2L, male = 1L))
as_factor(var)  # returned 'female'
```
and
```
var <- labelled(11L, c(female = 11L, male = 12L))
as_factor(var)  # returned '<NA>'
```

should be fixed: I added both test cases to testlabelled.R
 
Best regards,

Edwin