### PR TITLE
Minor typo fix in zap_labels function in labelled.R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # haven 0.2.0.9000
+* fixed bug in `zap_labels()` which was leaving labelled vectors unchanged
+  instead of leaving unlabelled vectors unchanged: thanks to markriseley.
 
 # haven 0.2.0
 * fixed a bug in `as_factor.labelled`, which generated <NA>'s and wrong 

--- a/R/labelled.R
+++ b/R/labelled.R
@@ -104,7 +104,7 @@ as_factor.labelled <- function(x, levels = c("labels", "values"),
 #' @export
 #' @rdname labelled
 zap_labels <- function(x) {
-  if (is.labelled(x))
+  if (!is.labelled(x))
     return(x)
 
   labelled <- x %in% attr(x, "labels")

--- a/tests/testthat/test-labelled.R
+++ b/tests/testthat/test-labelled.R
@@ -26,3 +26,14 @@ test_that("integer labels that are larger then label list work", {
   var <- labelled(11L, c(female = 11L, male = 12L))
   expect_equal(as_factor(var), factor("female", levels = c("female", "male")))
 })
+
+test_that("zap_labels replaces labels with NAs for labelled variable", {
+    var <- labelled(c(1L, 98L, 99L),  c(not_answered = 98L, not_applicable = 99L))
+    exp <- c(1L,NA,NA)
+    expect_equal(zap_labels(var), exp)
+})
+
+test_that("zap_labels returns variables not of class('labelled') unmodified", {
+    var <- c(1L, 98L, 99L)
+    expect_equal(zap_labels(var), var)
+})


### PR DESCRIPTION
zap_labels vignette doesn't work as intended currently. I think it's just a missing "!" :zap_labels is meant to act on class "labelled" not return it unmodified, as I understand it.