### PR TITLE
Relax type checking of numeric objects in labelled()

### DIFF
--- a/R/labelled.R
+++ b/R/labelled.R
@@ -44,7 +44,7 @@ labelled <- function(x, labels, is_na = NULL) {
   if (!is.numeric(x) && !is.character(x)) {
     stop("`x` must be either numeric or a character vector", call. = FALSE)
   }
-  if (typeof(x) != typeof(labels)) {
+  if (!is_coercible(x, labels)) {
     stop("`x` and `labels` must be same type", call. = FALSE)
   }
   if (is.null(labels)) {
@@ -64,6 +64,18 @@ labelled <- function(x, labels, is_na = NULL) {
     is_na = is_na,
     class = "labelled"
   )
+}
+
+is_coercible <- function(x, labels) {
+  if (typeof(x) == typeof(labels)) {
+    return(TRUE)
+  }
+
+  if (all(c(typeof(x), typeof(labels)) %in% c("integer", "double"))) {
+    return(TRUE)
+  }
+
+  FALSE
 }
 
 is.labelled <- function(x) inherits(x, "labelled")

--- a/tests/testthat/test-labelled.R
+++ b/tests/testthat/test-labelled.R
@@ -49,3 +49,8 @@ test_that("zap_labels returns variables not of class('labelled') unmodified", {
   var <- c(1L, 98L, 99L)
   expect_equal(zap_labels(var), var)
 })
+
+test_that("integer and double labels and values are compatible", {
+  expect_that(labelled(1, c(female = 2L, male = 1L)), not(throws_error()))
+  expect_that(labelled(1L, c(female = 2, male = 1)), not(throws_error()))
+})


### PR DESCRIPTION
This fixes a range of errors due to labels and values having mixed integer/double types. One example where this occurs is when importing the ANES datasets in DTA format.

In particular this caused the `[.labelled` method to fail, and also `print.tbl_df()` as a remote consequence.