### PR TITLE
Update ReadStat sources #34 #92 #101

### DIFF
--- a/src/readstat.h
+++ b/src/readstat.h
@@ -42,7 +42,8 @@ typedef enum readstat_error_e {
     READSTAT_ERROR_ROW_WIDTH_MISMATCH,
     READSTAT_ERROR_BAD_FORMAT_STRING,
     READSTAT_ERROR_VALUE_TYPE_MISMATCH,
-    READSTAT_ERROR_WRITE
+    READSTAT_ERROR_WRITE,
+    READSTAT_ERROR_SEEK
 } readstat_error_t;
 
 const char *readstat_error_message(readstat_error_t error_code);
@@ -234,6 +235,8 @@ void readstat_label_string_value(readstat_label_set_t *label_set, const char *va
 // Now define your variables. Note that `width' is only used for READSTAT_TYPE_STRING variables.
 readstat_variable_t *readstat_add_variable(readstat_writer_t *writer, readstat_types_t type, size_t width,
         const char *name, const char *label, const char *format, readstat_label_set_t *label_set);
+void readstat_variable_add_missing_double_value(readstat_variable_t *variable, double value);
+void readstat_variable_add_missing_double_range(readstat_variable_t *variable, double lo, double hi);
 readstat_variable_t *readstat_get_variable(readstat_writer_t *writer, int index);
 
 // Optional metadata

--- a/src/readstat_error.c
+++ b/src/readstat_error.c
@@ -9,7 +9,7 @@ const char *readstat_error_message(readstat_error_t error_code) {
         return "Unable to open file";
 
     if (error_code == READSTAT_ERROR_READ)
-        return "Unable to read file";
+        return "Unable to read from file";
 
     if (error_code == READSTAT_ERROR_MALLOC)
         return "Unable to allocate memory";
@@ -40,6 +40,9 @@ const char *readstat_error_message(readstat_error_t error_code) {
 
     if (error_code == READSTAT_ERROR_WRITE)
         return "Unable to write data";
+
+    if (error_code == READSTAT_ERROR_SEEK)
+        return "Unable to seek within file";
 
     return "Unknown error";
 }

--- a/src/readstat_io.h
+++ b/src/readstat_io.h
@@ -1,5 +1,12 @@
 
 int readstat_open(const char *filename);
 int readstat_close(int fd);
+#if defined _WIN32 || defined __CYGWIN__
+_off64_t readstat_lseek(int fildes, _off64_t offset, int whence);
+#elif defined _AIX
+off64_t readstat_lseek(int fildes, off64_t offset, int whence);
+#else
+off_t readstat_lseek(int fildes, off_t offset, int whence);
+#endif
 readstat_error_t readstat_update_progress(int fd, size_t file_size, 
         readstat_progress_handler progress_handler, void *user_ctx);

--- a/src/readstat_por.c
+++ b/src/readstat_por.c
@@ -143,7 +143,7 @@ static int read_bytes(readstat_por_ctx_t *ctx, void *dst, size_t len) {
         }
         for (; i<line_len; i++) {
             buf[i] = ctx->space;
-            if (lseek(ctx->fd, -1, SEEK_CUR) == -1)
+            if (readstat_lseek(ctx->fd, -1, SEEK_CUR) == -1)
                 return -1;
         }
         if (skip_newline(ctx->fd) == -1)
@@ -172,7 +172,7 @@ static int read_bytes(readstat_por_ctx_t *ctx, void *dst, size_t len) {
         }
         for (; i<bytes_left; i++) {
             buf[i] = ctx->space;
-            if (lseek(ctx->fd, -1, SEEK_CUR) == -1)
+            if (readstat_lseek(ctx->fd, -1, SEEK_CUR) == -1)
                 return -1;
         }
         memcpy((char *)dst + offset, buf, bytes_left);
@@ -620,13 +620,13 @@ readstat_error_t readstat_parse_por(readstat_parser_t *parser, const char *filen
         return READSTAT_ERROR_OPEN;
     }
 
-    if ((ctx->file_size = lseek(ctx->fd, 0, SEEK_END)) == -1) {
-        retval = READSTAT_ERROR_READ;
+    if ((ctx->file_size = readstat_lseek(ctx->fd, 0, SEEK_END)) == -1) {
+        retval = READSTAT_ERROR_SEEK;
         goto cleanup;
     }
 
-    if (lseek(ctx->fd, 0, SEEK_SET) == -1) {
-        retval = READSTAT_ERROR_READ;
+    if (readstat_lseek(ctx->fd, 0, SEEK_SET) == -1) {
+        retval = READSTAT_ERROR_SEEK;
         goto cleanup;
     }
     

--- a/src/readstat_spss.c
+++ b/src/readstat_spss.c
@@ -117,6 +117,23 @@ readstat_value_t spss_boxed_value(double fp_value) {
     return value;
 }
 
+uint64_t spss_64bit_value(readstat_value_t value) {
+    double dval = readstat_double_value(value);
+    uint64_t special_val;
+    memcpy(&special_val, &dval, sizeof(double));
+
+    if (isinf(dval)) {
+        if (dval < 0.0) {
+            special_val = SAV_LOWEST_DOUBLE;
+        } else {
+            special_val = SAV_HIGHEST_DOUBLE;
+        }
+    } else if (isnan(dval)) {
+        special_val = SAV_MISSING_DOUBLE;
+    }
+    return special_val;
+}
+
 readstat_missingness_t spss_missingness_for_info(spss_varinfo_t *info) {
     readstat_missingness_t missingness;
     memset(&missingness, 0, sizeof(readstat_missingness_t));

--- a/src/readstat_spss.h
+++ b/src/readstat_spss.h
@@ -83,3 +83,4 @@ readstat_missingness_t spss_missingness_for_info(spss_varinfo_t *info);
 readstat_variable_t *spss_init_variable_for_info(spss_varinfo_t *info);
 void spss_free_variable(readstat_variable_t *);
 
+uint64_t spss_64bit_value(readstat_value_t value);

--- a/src/readstat_variable.c
+++ b/src/readstat_variable.c
@@ -2,6 +2,19 @@
 #include <stdlib.h>
 #include "readstat.h"
 
+static readstat_value_t make_blank_value();
+static readstat_value_t make_double_value(double dval);
+
+static readstat_value_t make_blank_value() {
+    readstat_value_t value = { .is_system_missing = 1, .v = { .double_value = NAN }, .type = READSTAT_TYPE_DOUBLE };
+    return value;
+}
+
+static readstat_value_t make_double_value(double dval) {
+    readstat_value_t value = { .v = { .double_value = dval }, .type = READSTAT_TYPE_DOUBLE };
+    return value;
+}
+
 const char *readstat_variable_get_name(readstat_variable_t *variable) {
     if (variable->name[0])
         return variable->name;
@@ -31,11 +44,6 @@ int readstat_variable_get_missing_ranges_count(readstat_variable_t *variable) {
     return variable->missingness.missing_ranges_count;
 }
 
-static readstat_value_t make_blank_value() {
-    readstat_value_t value = { .is_system_missing = 1, .v = { .double_value = NAN }, .type = READSTAT_TYPE_DOUBLE };
-    return value;
-}
-
 readstat_value_t readstat_variable_get_missing_range_lo(readstat_variable_t *variable, int i) {
     if (i < variable->missingness.missing_ranges_count &&
             2*i+1 < sizeof(variable->missingness.missing_ranges)/sizeof(variable->missingness.missing_ranges[0])) {
@@ -53,3 +61,17 @@ readstat_value_t readstat_variable_get_missing_range_hi(readstat_variable_t *var
 
     return make_blank_value();
 }
+
+void readstat_variable_add_missing_double_value(readstat_variable_t *variable, double value) {
+    readstat_variable_add_missing_double_range(variable, value, value);
+}
+
+void readstat_variable_add_missing_double_range(readstat_variable_t *variable, double lo, double hi) {
+    int i = readstat_variable_get_missing_ranges_count(variable);
+    if (2*i < sizeof(variable->missingness.missing_ranges)/sizeof(variable->missingness.missing_ranges[0])) {
+        variable->missingness.missing_ranges[2*i] = make_double_value(lo);
+        variable->missingness.missing_ranges[2*i+1] = make_double_value(hi);
+        variable->missingness.missing_ranges_count++;
+    }
+}
+


### PR DESCRIPTION
Brings in the latest and greatest bug fixes from ReadStat, including large file support for Windows and AIX. It also addresses the infamous "A row was not the expected length" error with some compressed SAS files.

One new part of the writer API worth mentioning: 

```{C}
void readstat_variable_add_missing_double_value(readstat_variable_t *variable, double value);
void readstat_variable_add_missing_double_range(readstat_variable_t *variable, double lo, double hi);
```

I.e. for SPSS files you can now declare custom missing values and missing ranges.