### PR TITLE
Update ReadStat sources #121

### DIFF
--- a/src/readstat_sas_catalog.c
+++ b/src/readstat_sas_catalog.c
@@ -132,11 +132,9 @@ static readstat_error_t sas_catalog_parse_block(const char *data, size_t data_si
     }
 
     if ((data[2] & 0x80)) { // has long name
-        /* Uncomment to return long name to client code instead of short name
-           retval = readstat_convert(name, sizeof(name), &data[106+pad], 32, ctx->converter);
-           if (retval != READSTAT_OK)
-           goto cleanup;
-           */
+        retval = readstat_convert(name, sizeof(name), &data[106+pad], 32, ctx->converter);
+        if (retval != READSTAT_OK)
+            goto cleanup;
         pad += 32;
     }
 

--- a/src/readstat_sas_catalog.c
+++ b/src/readstat_sas_catalog.c
@@ -91,8 +91,8 @@ static readstat_error_t sas_parse_value_labels(const char *value_start, size_t v
         } else {
             uint64_t val = sas_read8(&lbp1[22], bswap_doubles);
             double dval = NAN;
-            if (val >= 0x000000FFFFFFFFFF && val <= 0x0000FFFFFFFFFFFF) {
-                value.tag = (val >> 40) & 0xFF;
+            if ((val | 0xFF0000000000) == 0xFFFFFFFFFFFF) {
+                value.tag = (val >> 40);
                 value.is_system_missing = 1;
             } else {
                 memcpy(&dval, &val, 8);


### PR DESCRIPTION
Value label set names longer than 8 bytes (e.g. `CLAVICLE_FORMAT`) were not being correctly matched to their variables. Fixes #121.