### PR TITLE
Fix writing dates/times to dta

### DIFF
--- a/src/DfWriter.cpp
+++ b/src/DfWriter.cpp
@@ -138,7 +138,7 @@ public:
     return Rf_translateCharUTF8(STRING_ELT(label, 0));
   }
 
-  void defineVariable(IntegerVector x, std::string name) {
+  void defineVariable(IntegerVector x, std::string name, const char* format = NULL) {
     readstat_label_set_t* labelSet = NULL;
     if (rClass(x) == "factor") {
       labelSet = readstat_add_label_set(writer_, READSTAT_TYPE_INT32, name.c_str());
@@ -158,10 +158,10 @@ public:
     }
 
     readstat_add_variable(writer_, READSTAT_TYPE_INT32, 0, name.c_str(),
-      var_label(x), NULL, labelSet);
+      var_label(x), format, labelSet);
   }
 
-  void defineVariable(NumericVector x, std::string name) {
+  void defineVariable(NumericVector x, std::string name, const char* format = NULL) {
     readstat_label_set_t* labelSet = NULL;
     if (rClass(x) == "labelled") {
       labelSet = readstat_add_label_set(writer_, READSTAT_TYPE_DOUBLE, name.c_str());
@@ -174,10 +174,10 @@ public:
     }
 
     readstat_add_variable(writer_, READSTAT_TYPE_DOUBLE, 0, name.c_str(),
-      var_label(x), NULL, labelSet);
+      var_label(x), format, labelSet);
   }
 
-  void defineVariable(CharacterVector x, std::string name) {
+  void defineVariable(CharacterVector x, std::string name, const char* format = NULL) {
     readstat_label_set_t* labelSet = NULL;
     if (rClass(x) == "labelled") {
       labelSet = readstat_add_label_set(writer_, READSTAT_TYPE_STRING, name.c_str());
@@ -197,7 +197,7 @@ public:
     }
 
     readstat_add_variable(writer_, READSTAT_TYPE_STRING, max_length,
-      name.c_str(), var_label(x), NULL, labelSet);
+      name.c_str(), var_label(x), format, labelSet);
   }
 
   void checkStatus(readstat_error_t err) {

--- a/src/DfWriter.cpp
+++ b/src/DfWriter.cpp
@@ -29,6 +29,96 @@ public:
     } catch (...) {};
   }
 
+  void write_dta() {
+    CharacterVector names = as<CharacterVector>(x_.attr("names"));
+
+    int p = x_.size();
+    if (p == 0)
+      return;
+
+    // Define variables
+    for (int j = 0; j < p; ++j) {
+      RObject col = x_[j];
+      std::string name(names[j]);
+      switch(TYPEOF(col)) {
+      case LGLSXP:
+        defineVariable(as<IntegerVector>(col), name);
+        break;
+      case INTSXP:
+        defineVariable(as<IntegerVector>(col), name);
+        break;
+      case REALSXP:
+        defineVariable(as<NumericVector>(col), name);
+        break;
+      case STRSXP:
+        defineVariable(as<CharacterVector>(col), name);
+        break;
+      default:
+        stop("Variables of type %s not supported yet",
+             Rf_type2char(TYPEOF(col)));
+      }
+    }
+
+    int n = Rf_length(x_[0]);
+
+    readstat_begin_writing_dta(writer_, this, n);
+
+    // Write data
+    for (int i = 0; i < n; ++i) {
+      readstat_begin_row(writer_);
+      for (int j = 0; j < p; ++j) {
+        RObject col = x_[j];
+        readstat_variable_t* var = readstat_get_variable(writer_, j);
+
+        switch (TYPEOF(col)) {
+        case LGLSXP: {
+          int val = LOGICAL(col)[i];
+          if (val == NA_LOGICAL) {
+            readstat_insert_missing_value(writer_, var);
+          } else {
+            readstat_insert_int32_value(writer_, var, val);
+          }
+          break;
+        }
+        case INTSXP: {
+          int val = INTEGER(col)[i];
+          if (val == NA_INTEGER) {
+            readstat_insert_missing_value(writer_, var);
+          } else {
+            readstat_insert_int32_value(writer_, var, val);
+          }
+          break;
+        }
+        case REALSXP: {
+          double val = REAL(col)[i];
+          if (ISNAN(val)) {
+            readstat_insert_missing_value(writer_, var);
+          } else {
+            readstat_insert_double_value(writer_, var, val);
+          }
+          break;
+        }
+        case STRSXP: {
+          SEXP val = STRING_ELT(col, i);
+          if (val == NA_STRING) {
+            readstat_insert_missing_value(writer_, var);
+          } else {
+            readstat_insert_string_value(writer_, var, Rf_translateCharUTF8(val));
+          }
+          break;
+        }
+          break;
+        default:
+          break;
+        }
+      }
+      readstat_end_row(writer_);
+    }
+
+    readstat_end_writing(writer_);
+
+  }
+
   void write_sav() {
     CharacterVector names = as<CharacterVector>(x_.attr("names"));
 
@@ -60,16 +150,8 @@ public:
     }
 
     int n = Rf_length(x_[0]);
-    switch (type_) {
-    case HAVEN_STATA:
-      readstat_begin_writing_dta(writer_, this, n);
-      break;
-    case HAVEN_SPSS:
-      readstat_begin_writing_sav(writer_, this, n);
-      break;
-    default:
-      Rcpp::stop("Not currently supported");
-    }
+
+    readstat_begin_writing_sav(writer_, this, n);
 
     // Write data
     for (int i = 0; i < n; ++i) {
@@ -232,5 +314,5 @@ void write_sav_(List data, std::string path) {
 
 // [[Rcpp::export]]
 void write_dta_(List data, std::string path) {
-  Writer(data, path, HAVEN_STATA).write_sav();
+  Writer(data, path, HAVEN_STATA).write_dta();
 }

--- a/src/DfWriter.cpp
+++ b/src/DfWriter.cpp
@@ -270,13 +270,17 @@ public:
   void defineVariable(NumericVector x, std::string name, const char* format = NULL) {
     readstat_label_set_t* labelSet = NULL;
     if (rClass(x) == "labelled") {
-      labelSet = readstat_add_label_set(writer_, READSTAT_TYPE_DOUBLE, name.c_str());
+      if(type_ == HAVEN_STATA) {
+        warning("Non-integer labelleds are unsupported in Stata.");
+      } else {
+        labelSet = readstat_add_label_set(writer_, READSTAT_TYPE_DOUBLE, name.c_str());
 
-      NumericVector values = as<NumericVector>(x.attr("labels"));
-      CharacterVector labels = as<CharacterVector>(values.attr("names"));
+        NumericVector values = as<NumericVector>(x.attr("labels"));
+        CharacterVector labels = as<CharacterVector>(values.attr("names"));
 
-      for (int i = 0; i < values.size(); ++i)
-        readstat_label_double_value(labelSet, values[i], std::string(labels[i]).c_str());
+        for (int i = 0; i < values.size(); ++i)
+          readstat_label_double_value(labelSet, values[i], std::string(labels[i]).c_str());
+      }
     }
 
     readstat_add_variable(writer_, READSTAT_TYPE_DOUBLE, 0, name.c_str(),
@@ -286,13 +290,17 @@ public:
   void defineVariable(CharacterVector x, std::string name, const char* format = NULL) {
     readstat_label_set_t* labelSet = NULL;
     if (rClass(x) == "labelled") {
-      labelSet = readstat_add_label_set(writer_, READSTAT_TYPE_STRING, name.c_str());
+      if(type_ == HAVEN_STATA) {
+        warning("Non-integer labelleds are unsupported in Stata.");
+      } else {
+        labelSet = readstat_add_label_set(writer_, READSTAT_TYPE_STRING, name.c_str());
 
-      CharacterVector values = as<CharacterVector>(x.attr("labels"));
-      CharacterVector labels = as<CharacterVector>(values.attr("names"));
+        CharacterVector values = as<CharacterVector>(x.attr("labels"));
+        CharacterVector labels = as<CharacterVector>(values.attr("names"));
 
-      for (int i = 0; i < values.size(); ++i)
-        readstat_label_string_value(labelSet, values[i], std::string(labels[i]).c_str());
+        for (int i = 0; i < values.size(); ++i)
+          readstat_label_string_value(labelSet, values[i], std::string(labels[i]).c_str());
+      }
     }
 
     int max_length = 0;

--- a/tests/testthat/test-write-sav.R
+++ b/tests/testthat/test-write-sav.R
@@ -1,7 +1,4 @@
-context("write")
-
-# writing uses exactly the same path for sav and dta, so don't need
-# to test both
+context("write_sav")
 
 roundtrip <- function(x) {
   tmp <- tempfile()

--- a/tests/testthat/test-write-stata.R
+++ b/tests/testthat/test-write-stata.R
@@ -1,0 +1,64 @@
+context("write_stata")
+
+roundtrip <- function(x) {
+  tmp <- tempfile()
+  write_dta(x, tmp)
+  read_dta(tmp)
+}
+
+roundtrip_var <- function(x) {
+  df <- list(x = x)
+  class(df) <- "data.frame"
+  attr(df, "row.names") <- .set_row_names(length(x))
+  roundtrip(df)$x
+}
+
+test_that("can roundtrip basic types", {
+  x <- runif(10)
+  expect_equal(roundtrip_var(x), x)
+  expect_equal(roundtrip_var(1:10), 1:10)
+  expect_equal(roundtrip_var(c(TRUE, FALSE)), c(1, 0))
+  expect_equal(roundtrip_var(letters), letters)
+})
+
+test_that("can roundtrip missing values (as much as possible)", {
+  expect_equal(roundtrip_var(NA), NA_integer_)
+  expect_equal(roundtrip_var(NA_real_), NA_real_)
+  expect_equal(roundtrip_var(NA_integer_), NA_integer_)
+  expect_equal(roundtrip_var(NA_character_), "")
+})
+
+test_that("factors become labelleds", {
+  f <- factor(c("a", "b"), levels = letters[1:3])
+  rt <- roundtrip_var(f)
+
+  expect_is(rt, "labelled")
+  expect_equal(as.vector(rt), 1:2)
+  expect_equal(attr(rt, "labels"), c(a = 1, b = 2, c = 3))
+})
+
+test_that("labels are preserved", {
+  x <- 1:10
+  attr(x, "label") <- "abc"
+
+  expect_equal(attr(roundtrip_var(x), "label"), "abc")
+})
+
+test_that("labelleds are round tripped", {
+  int <- labelled(c(1L, 2L), c(a = 1L, b = 3L))
+  num <- labelled(c(1, 2), c(a = 1, b = 3))
+  chr <- labelled(c("a", "b"), c(a = "b", b = "a"))
+
+  expect_equal(roundtrip_var(int), int)
+  expect_equal(roundtrip_var(num), num)
+  expect_equal(roundtrip_var(chr), chr)
+})
+
+test_that("factors become labelleds", {
+  f <- factor(c("a", "b"), levels = letters[1:3])
+  rt <- roundtrip_var(f)
+
+  expect_is(rt, "labelled")
+  expect_equal(as.vector(rt), 1:2)
+  expect_equal(attr(rt, "labels"), c(a = 1, b = 2, c = 3))
+})

--- a/tests/testthat/test-write-stata.R
+++ b/tests/testthat/test-write-stata.R
@@ -21,11 +21,23 @@ test_that("can roundtrip basic types", {
   expect_equal(roundtrip_var(letters), letters)
 })
 
+test_that("can rountrip dates", {
+  today <- Sys.Date()
+  expect_equal(roundtrip_var(today), today)
+})
+
+test_that("can rountrip datetimes", {
+  now <- Sys.time()
+  expect_equal(roundtrip_var(now), now)
+})
+
 test_that("can roundtrip missing values (as much as possible)", {
   expect_equal(roundtrip_var(NA), NA_integer_)
   expect_equal(roundtrip_var(NA_real_), NA_real_)
   expect_equal(roundtrip_var(NA_integer_), NA_integer_)
   expect_equal(roundtrip_var(NA_character_), "")
+  expect_equal(roundtrip_var(as.Date(NA)), as.Date(NA))
+  expect_equal(roundtrip_var(as.POSIXct(NA)), as.POSIXct(NA))
 })
 
 test_that("factors become labelleds", {

--- a/tests/testthat/test-write-stata.R
+++ b/tests/testthat/test-write-stata.R
@@ -56,14 +56,22 @@ test_that("labels are preserved", {
   expect_equal(attr(roundtrip_var(x), "label"), "abc")
 })
 
-test_that("labelleds are round tripped", {
+test_that("integer labelleds are round tripped", {
   int <- labelled(c(1L, 2L), c(a = 1L, b = 3L))
+  expect_equal(roundtrip_var(int), int)
+})
+
+test_that("non-integer labelleds are unsupported", {
   num <- labelled(c(1, 2), c(a = 1, b = 3))
   chr <- labelled(c("a", "b"), c(a = "b", b = "a"))
 
-  expect_equal(roundtrip_var(int), int)
-  expect_equal(roundtrip_var(num), num)
-  expect_equal(roundtrip_var(chr), chr)
+  expect_warning(num_rt <- roundtrip_var(num), "(not |un)supported")
+  attributes(num) <- NULL
+  expect_equal(num_rt, num)
+
+  expect_warning(chr_rt <- roundtrip_var(chr), "(not |un)supported")
+  attributes(chr) <- NULL
+  expect_equal(chr_rt, chr)
 })
 
 test_that("factors become labelleds", {


### PR DESCRIPTION
Writing dates and datetimes to dta is currently broken (#139), since haven does not convert them to the Stata epoch (1960-01-01). This pull request fixes that.

Instead of adding more conditionals to write_sav, I opted to create separate write_dta and write_sav methods. I feel that this makes it easier for me and others who are only familiar with one of the formats to contribute. I also expect the two functions to diverge further when #143 is fixed. Perhaps it would make sense at some point in the future to have separate classes for each of the formats inheriting from DfWriter.

Closes #139
Closes #140
Closes #144