### PR TITLE
Preserve unused labels when converting labelled with as_factor

### DIFF
--- a/R/labelled.R
+++ b/R/labelled.R
@@ -152,6 +152,7 @@ as_factor.labelled <- function(x, levels = c("default", "labels", "values", "bot
 
     # Replace each value with its label
     levs <- replace_with(sort(unique(x)), unname(labels), names(labels))
+    levs <- unique(c(names(labels), levs))
     x <- replace_with(x, unname(labels), names(labels))
 
     factor(x, levels = levs, ordered = ordered)

--- a/tests/testthat/test-as-factor.R
+++ b/tests/testthat/test-as-factor.R
@@ -13,15 +13,21 @@ test_that("converts characters to factors", {
 
 # Labelled values ---------------------------------------------------------
 
+test_that("labels are preserved even if they are not present in values #172", {
+  s1 <- labelled(rep(1, 3), c("A" = 1, "B" = 2, "C" = 3))
+  exp <- factor(rep("A", 3), levels = c("A", "B", "C"))
+  expect_equal(as_factor(s1), exp)
+})
+
 test_that("all values are preserved", {
   s1 <- labelled(1:3, c("A" = 2))
-  exp <- factor(c("1", "A", "3"), levels = c("1", "A", "3"))
+  exp <- factor(c("1", "A", "3"), levels = c("A", "1", "3"))
   expect_equal(as_factor(s1), exp)
 })
 
 test_that("character labelled converts to factor", {
   s1 <- labelled(c("M", "M", "F"), c(Male = "M", Female = "F"))
-  exp <- factor(c("Male", "Male", "Female"), levels = c("Female", "Male"))
+  exp <- factor(c("Male", "Male", "Female"), levels = c("Male", "Female"))
   expect_equal(as_factor(s1), exp)
 })
 


### PR DESCRIPTION
Feature request and simple fix for #172. The idea is to include all labels to safely convert labelled variables to factors without information-loss. Users can instead explicitly call droplevels() after converting to get the current output.

I also think it would be best to leave labels (in the order they were entered) as the first levels in the resulting factor, and any unexpected values as the last levels (after sorting). e.g:

```r
  s1 <- labelled(c("B", "A", "C"), c("C" = "C"))
  exp <- factor(c("B", "A", "C"), levels = c("C", "A", "B"))
  expect_equal(as_factor(s1), exp)
```
