### PR TITLE
Printing also the type of labelled objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,8 @@
   (@markriseley, #69), and only drops label attributes; it no longer replaces
   labelled values with `NA`s. It also gains a data frame method that zaps
   the labels from every column.
+  
+* `print.labelled()` and `print.labelled_spss()` now display the type.
 
 # haven 0.2.0
 

--- a/R/labelled.R
+++ b/R/labelled.R
@@ -76,7 +76,7 @@ is.labelled <- function(x) inherits(x, "labelled")
 
 #' @export
 print.labelled <- function(x, ..., digits = getOption("digits")) {
-  cat("<Labelled>\n")
+  cat("<Labelled ", typeof(x), ">\n", sep = "")
 
   if (is.double(x)) {
     print_tagged_na(x, digits = digits)

--- a/R/labelled_spss.R
+++ b/R/labelled_spss.R
@@ -43,7 +43,7 @@ labelled_spss <- function(x, labels, na_values = NULL, na_range = NULL) {
 
 #' @export
 print.labelled_spss <- function(x, ...) {
-  cat("<Labelled SPSS>\n")
+  cat("<Labelled SPSS ", typeof(x), ">\n", sep = "")
 
   xx <- x
   attributes(xx) <- NULL

--- a/tests/testthat/labelled-output.txt
+++ b/tests/testthat/labelled-output.txt
@@ -1,4 +1,4 @@
-<Labelled>
+<Labelled double>
 [1]     1     2     3     4     5    NA NA(x) NA(y) NA(z)
 
 Labels:

--- a/tests/testthat/labelled-spss-output.txt
+++ b/tests/testthat/labelled-spss-output.txt
@@ -1,4 +1,4 @@
-<Labelled SPSS>
+<Labelled SPSS integer>
 [1] 1 2 3 4 5
 Missing values: 1, 2
 Missing range:  [3, Inf]


### PR DESCRIPTION
Proposition to also display the type of a labelled object (as this information is "hidden" by the labelled class).

Example:
```
> s1 <- labelled(c("M", "M", "F"), c(Male = "M", Female = "F"))
> s1
<Labelled (character)>
[1] M M F

Labels:
 value  label
     M   Male
     F Female
> s2 <- labelled(c(1, 1, 2), c(Male = 1, Female = 2))
> s2
<Labelled (double)>
[1] 1 1 2

Labels:
 value  label
     1   Male
     2 Female
```