### PR TITLE
Adapt validate_dta to comply with stata variable name length

### DIFF
--- a/R/haven.R
+++ b/R/haven.R
@@ -147,7 +147,7 @@ write_dta <- function(data, path) {
 
 validate_dta <- function(data) {
   # Check variable names
-  bad_names <- !grepl("^[a-zA-Z0-9_]+$", names(data))
+  bad_names <- !grepl("^[a-zA-Z0-9_]{1,32}$", names(data))
   if (any(bad_names)) {
     stop(
       "The following variable names are not valid Stata variables: ",


### PR DESCRIPTION
Variables names in stata cannot exceed 32 characters. Adapted the REGEX that checks name format to comply with this.