### PR TITLE
Fix Windows build

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -2,4 +2,6 @@ CFILES = $(wildcard *.c sas/*.c spss/*.c stata/*.c)
 CPPFILES = $(wildcard *.cpp)
 
 SOURCES = $(CFILES) $(CPPFILES)
+
+# This must be defined identically in Makevars.win
 OBJECTS = $(CFILES:.c=.o) $(CPPFILES:.cpp=.o)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,1 +1,6 @@
+include Makevars
+
+# This is also defined in Makevars, but somehow the definition from there is not used
+OBJECTS = $(CFILES:.c=.o) $(CPPFILES:.cpp=.o)
+
 PKG_LIBS=-lRiconv


### PR DESCRIPTION
Using `include` in `Makevars.win`, but need to set `OBJECTS` manually.

Fixes #207.